### PR TITLE
making initialization public function

### DIFF
--- a/contracts/PolygonZkEVM.sol
+++ b/contracts/PolygonZkEVM.sol
@@ -377,7 +377,7 @@ contract PolygonZkEVM is
         IPolygonZkEVMBridge _bridgeAddress,
         uint64 _chainID,
         uint64 _forkID
-    ) external initializer {
+    ) public initializer {
         globalExitRootManager = _globalExitRootManager;
         matic = _matic;
         rollupVerifier = _rollupVerifier;

--- a/contracts/PolygonZkEVMBridge.sol
+++ b/contracts/PolygonZkEVMBridge.sol
@@ -91,7 +91,7 @@ contract PolygonZkEVMBridge is
         address _polygonZkEVMaddress,
         address _gasTokenAddress,
         bool _isDeployedOnL2
-    ) external virtual initializer {
+    ) public virtual initializer {
         networkID = _networkID;
         globalExitRootManager = _globalExitRootManager;
         polygonZkEVMaddress = _polygonZkEVMaddress;


### PR DESCRIPTION
This is required to call these initiational functions from the parent contract(which is not external)