### PR TITLE
OnlyInitializing

### DIFF
--- a/contracts/PolygonZkEVMBridgeWrapper.sol
+++ b/contracts/PolygonZkEVMBridgeWrapper.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity 0.8.17;
+
+import "./inheritedMainContracts/PolygonZkEVMBridge.sol";
+
+contract PolygonZkEVMBridgeWrapper is PolygonZkEVMBridge{
+    function initialize(
+        uint32 _networkID,
+        IBasePolygonZkEVMGlobalExitRoot _globalExitRootManager,
+        address _polygonZkEVMaddress,
+        address _gasTokenAddress,
+        bool _isDeployedOnL2
+    ) public virtual override initializer {
+        PolygonZkEVMBridge.initialize(_networkID, _globalExitRootManager, _polygonZkEVMaddress, _gasTokenAddress, _isDeployedOnL2);
+    }
+}

--- a/contracts/PolygonZkEVMTimelock.sol
+++ b/contracts/PolygonZkEVMTimelock.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts/governance/TimelockController.sol";
-import "./PolygonZkEVM.sol";
+import "./inheritedMainContracts/PolygonZkEVM.sol";
 
 /**
  * @dev Contract module which acts as a timelocked controller.

--- a/contracts/PolygonZkEVMWrapper.sol
+++ b/contracts/PolygonZkEVMWrapper.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity 0.8.17;
+
+import "./inheritedMainContracts/PolygonZkEVM.sol";
+
+contract PolygonZkEVMWrapper is PolygonZkEVM{
+    function initialize(
+        InitializePackedParameters calldata initializePackedParameters,
+        bytes32 genesisRoot,
+        string memory _trustedSequencerURL,
+        string memory _networkName,
+        string calldata _version,
+        IPolygonZkEVMGlobalExitRoot _globalExitRootManager,
+        IERC20Upgradeable _matic,
+        IVerifierRollup _rollupVerifier,
+        IPolygonZkEVMBridge _bridgeAddress,
+        uint64 _chainID,
+        uint64 _forkID
+    ) public override initializer {
+        PolygonZkEVM.initialize(
+            initializePackedParameters,
+            genesisRoot,
+            _trustedSequencerURL,
+            _networkName,
+            _version,
+            _globalExitRootManager,
+            _matic,
+            _rollupVerifier,
+            _bridgeAddress,
+            _chainID,
+            _forkID
+        );
+    }
+}

--- a/contracts/inheritedMainContracts/PolygonZkEVM.sol
+++ b/contracts/inheritedMainContracts/PolygonZkEVM.sol
@@ -3,12 +3,12 @@ pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import "./interfaces/IVerifierRollup.sol";
-import "./interfaces/IPolygonZkEVMGlobalExitRoot.sol";
-import "./lib/EmergencyManager.sol";
-import "./interfaces/IPolygonZkEVMErrors.sol";
-import "./interfaces/IPolygonZkEVM.sol";
-import "./interfaces/IPolygonZkEVMBridge.sol";
+import "../interfaces/IVerifierRollup.sol";
+import "../interfaces/IPolygonZkEVMGlobalExitRoot.sol";
+import "../lib/EmergencyManager.sol";
+import "../interfaces/IPolygonZkEVMErrors.sol";
+import "../interfaces/IPolygonZkEVM.sol";
+import "../interfaces/IPolygonZkEVMBridge.sol";
 
 /**
  * Contract responsible for managing the states and the updates of L2 network.
@@ -377,7 +377,7 @@ contract PolygonZkEVM is
         IPolygonZkEVMBridge _bridgeAddress,
         uint64 _chainID,
         uint64 _forkID
-    ) public initializer {
+    ) public virtual onlyInitializing {
         globalExitRootManager = _globalExitRootManager;
         matic = _matic;
         rollupVerifier = _rollupVerifier;

--- a/contracts/inheritedMainContracts/PolygonZkEVMBridge.sol
+++ b/contracts/inheritedMainContracts/PolygonZkEVMBridge.sol
@@ -2,15 +2,15 @@
 
 pragma solidity 0.8.17;
 
-import "./lib/DepositContract.sol";
+import "../lib/DepositContract.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
-import "./lib/TokenWrapped.sol";
-import "./interfaces/IBasePolygonZkEVMGlobalExitRoot.sol";
-import "./interfaces/IBridgeMessageReceiver.sol";
-import "./interfaces/IPolygonZkEVMBridge.sol";
+import "../lib/TokenWrapped.sol";
+import "../interfaces/IBasePolygonZkEVMGlobalExitRoot.sol";
+import "../interfaces/IBridgeMessageReceiver.sol";
+import "../interfaces/IPolygonZkEVMBridge.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol";
-import "./lib/EmergencyManager.sol";
-import "./lib/GlobalExitRootLib.sol";
+import "../lib/EmergencyManager.sol";
+import "../lib/GlobalExitRootLib.sol";
 
 /**
  * PolygonZkEVMBridge that will be deployed on both networks Ethereum and Polygon zkEVM
@@ -91,7 +91,7 @@ contract PolygonZkEVMBridge is
         address _polygonZkEVMaddress,
         address _gasTokenAddress,
         bool _isDeployedOnL2
-    ) public virtual initializer {
+    ) public virtual onlyInitializing {
         networkID = _networkID;
         globalExitRootManager = _globalExitRootManager;
         polygonZkEVMaddress = _polygonZkEVMaddress;
@@ -741,7 +741,7 @@ contract PolygonZkEVMBridge is
             // we call without checking the result, in case it fails and he doesn't have enough balance
             // the following transferFrom should be fail. This prevents DoS attacks from using a signature
             // before the smartcontract call
-            /* solhint-disable avoid-low-level-calls */
+            /* solhint-disable avoid-low-level-calls,  */
             address(token).call(
                 abi.encodeWithSelector(
                     _PERMIT_SIGNATURE,

--- a/contracts/mocks/PolygonZkEVMBridgeMock.sol
+++ b/contracts/mocks/PolygonZkEVMBridgeMock.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity 0.8.17;
-import "../PolygonZkEVMBridge.sol";
+import "../PolygonZkEVMBridgeWrapper.sol";
 
 /**
  * PolygonZkEVMBridge that will be deployed on both networks Ethereum and Polygon zkEVM
  * Contract responsible to manage the token interactions with other networks
  */
-contract PolygonZkEVMBridgeMock is PolygonZkEVMBridge {
+contract PolygonZkEVMBridgeMock is PolygonZkEVMBridgeWrapper {
     uint256 public maxEtherBridge;
 
     /**

--- a/contracts/mocks/PolygonZkEVMMock.sol
+++ b/contracts/mocks/PolygonZkEVMMock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity 0.8.17;
 
-import "../PolygonZkEVM.sol";
+import "../PolygonZkEVMWrapper.sol";
 
 /**
  * Contract responsible for managing the state and the updates of the L2 network
@@ -9,7 +9,7 @@ import "../PolygonZkEVM.sol";
  * The aggregators are forced to process and validate the sequencers transactions in the same order by using a verifier.
  * To enter and exit of the L2 network will be used a PolygonZkEVM Bridge smart contract
  */
-contract PolygonZkEVMMock is PolygonZkEVM {
+contract PolygonZkEVMMock is PolygonZkEVMWrapper {
 
     /**
      * @notice calculate accumulate input hash from parameters

--- a/contracts/testnet/PolygonZkEVMTestnetClearStorage.sol
+++ b/contracts/testnet/PolygonZkEVMTestnetClearStorage.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity 0.8.17;
 
-import "../PolygonZkEVM.sol";
+import "../inheritedMainContracts/PolygonZkEVM.sol";
 
 /**
  * Contract responsible for managing the state and the updates of the L2 network

--- a/contracts/testnet/PolygonZkEVMTestnetV2.sol
+++ b/contracts/testnet/PolygonZkEVMTestnetV2.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity 0.8.17;
 
-import "../PolygonZkEVM.sol";
+import "../PolygonZkEVMWrapper.sol";
 
 /**
  * Contract responsible for managing the state and the updates of the L2 network
  * This contract will NOT BE USED IN PRODUCTION, will be used only in testnet enviroment
  */
-contract PolygonZkEVMTestnetV2 is PolygonZkEVM {
+contract PolygonZkEVMTestnetV2 is PolygonZkEVMWrapper {
     // Indicates the current version
     uint256 public version;
 

--- a/deployment/1_createGenesis.js
+++ b/deployment/1_createGenesis.js
@@ -77,7 +77,7 @@ async function main() {
     const [proxyAdminAddress] = await create2Deployment(zkEVMDeployerContract, salt, deployTransactionAdmin, dataCallAdmin, deployer);
 
     // Deploy implementation PolygonZkEVMBridg
-    const polygonZkEVMBridgeFactory = await ethers.getContractFactory('PolygonZkEVMBridge', deployer);
+    const polygonZkEVMBridgeFactory = await ethers.getContractFactory('PolygonZkEVMBridgeWrapper', deployer);
     const deployTransactionBridge = (polygonZkEVMBridgeFactory.getDeployTransaction()).data;
     // Mandatory to override the gasLimit since the estimation with create are mess up D:
     const overrideGasLimit = ethers.BigNumber.from(5500000);

--- a/deployment/3_deployContracts.js
+++ b/deployment/3_deployContracts.js
@@ -179,7 +179,7 @@ async function main() {
     }
 
     // Deploy implementation PolygonZkEVMBridge
-    const polygonZkEVMBridgeFactory = await ethers.getContractFactory('PolygonZkEVMBridge', deployer);
+    const polygonZkEVMBridgeFactory = await ethers.getContractFactory('PolygonZkEVMBridgeWrapper', deployer);
     const deployTransactionBridge = (polygonZkEVMBridgeFactory.getDeployTransaction()).data;
     const dataCallNull = null;
     // Mandatory to override the gasLimit since the estimation with create are mess up D:
@@ -349,7 +349,7 @@ async function main() {
     console.log('networkName:', networkName);
     console.log('forkID:', forkID);
 
-    const PolygonZkEVMFactory = await ethers.getContractFactory('PolygonZkEVM', deployer);
+    const PolygonZkEVMFactory = await ethers.getContractFactory('PolygonZkEVMWrapper', deployer);
 
     let polygonZkEVMContract;
     let deploymentBlockNumber;

--- a/test/contracts/bridge.test.js
+++ b/test/contracts/bridge.test.js
@@ -54,7 +54,7 @@ describe('PolygonZkEVMBridge Contract', () => {
         await gasTokenContract.deployed();
 
         // deploy PolygonZkEVMBridge
-        const polygonZkEVMBridgeFactory = await ethers.getContractFactory('PolygonZkEVMBridge');
+        const polygonZkEVMBridgeFactory = await ethers.getContractFactory('PolygonZkEVMBridgeWrapper');
         polygonZkEVMBridgeContract = await upgrades.deployProxy(polygonZkEVMBridgeFactory, [], { initializer: false });
 
         // deploy global exit root manager

--- a/test/contracts/bridge_metadata.test.js
+++ b/test/contracts/bridge_metadata.test.js
@@ -42,7 +42,7 @@ describe('PolygonZkEVMBridge Contract werid metadata', () => {
         await gasTokenContract.deployed();
 
         // deploy PolygonZkEVMBridge
-        const polygonZkEVMBridgeFactory = await ethers.getContractFactory('PolygonZkEVMBridge');
+        const polygonZkEVMBridgeFactory = await ethers.getContractFactory('PolygonZkEVMBridgeWrapper');
         polygonZkEVMBridgeContract = await upgrades.deployProxy(polygonZkEVMBridgeFactory, [], { initializer: false });
 
         // deploy global exit root manager

--- a/test/contracts/bridge_permit.test.js
+++ b/test/contracts/bridge_permit.test.js
@@ -60,7 +60,7 @@ describe('PolygonZkEVMBridge Contract Permit tests', () => {
         await gasTokenContract.deployed();
 
         // deploy PolygonZkEVMBridge
-        const polygonZkEVMBridgeFactory = await ethers.getContractFactory('PolygonZkEVMBridge');
+        const polygonZkEVMBridgeFactory = await ethers.getContractFactory('PolygonZkEVMBridgeWrapper');
         polygonZkEVMBridgeContract = await upgrades.deployProxy(polygonZkEVMBridgeFactory, [], { initializer: false });
 
         // deploy global exit root manager

--- a/test/contracts/emergencyManager.test.js
+++ b/test/contracts/emergencyManager.test.js
@@ -89,7 +89,7 @@ describe('Emergency mode test', () => {
         });
 
         // deploy PolygonZkEVMBridge
-        const polygonZkEVMBridgeFactory = await ethers.getContractFactory('PolygonZkEVMBridge');
+        const polygonZkEVMBridgeFactory = await ethers.getContractFactory('PolygonZkEVMBridgeWrapper');
         polygonZkEVMBridgeContract = await upgrades.deployProxy(polygonZkEVMBridgeFactory, [], { initializer: false });
 
         // deploy PolygonZkEVMMock

--- a/test/contracts/polygonZkEVM.test.js
+++ b/test/contracts/polygonZkEVM.test.js
@@ -100,7 +100,7 @@ describe('Polygon ZK-EVM', () => {
         });
 
         // deploy PolygonZkEVMBridge
-        const polygonZkEVMBridgeFactory = await ethers.getContractFactory('PolygonZkEVMBridge');
+        const polygonZkEVMBridgeFactory = await ethers.getContractFactory('PolygonZkEVMBridgeWrapper');
         polygonZkEVMBridgeContract = await upgrades.deployProxy(polygonZkEVMBridgeFactory, [], { initializer: false });
 
         // deploy PolygonZkEVMMock

--- a/test/contracts/polygonZkEVMTestnetV2.test.js
+++ b/test/contracts/polygonZkEVMTestnetV2.test.js
@@ -90,7 +90,7 @@ describe('Polygon ZK-EVM TestnetV2', () => {
         });
 
         // deploy PolygonZkEVMBridge
-        const polygonZkEVMBridgeFactory = await ethers.getContractFactory('PolygonZkEVMBridge');
+        const polygonZkEVMBridgeFactory = await ethers.getContractFactory('PolygonZkEVMBridgeWrapper');
         polygonZkEVMBridgeContract = await upgrades.deployProxy(polygonZkEVMBridgeFactory, [], { initializer: false });
 
         // deploy PolygonZkEVMTestnet

--- a/test/contracts/real-prover/real-flow.test.js
+++ b/test/contracts/real-prover/real-flow.test.js
@@ -97,7 +97,7 @@ describe('Real flow test', () => {
         });
 
         // deploy PolygonZkEVMBridge
-        const polygonZkEVMBridgeFactory = await ethers.getContractFactory('PolygonZkEVMBridge');
+        const polygonZkEVMBridgeFactory = await ethers.getContractFactory('PolygonZkEVMBridgeWrapper');
         polygonZkEVMBridgeContract = await upgrades.deployProxy(polygonZkEVMBridgeFactory, [], { initializer: false });
 
         // deploy PolygonZkEVMMock

--- a/test/contracts/timelockUpgradeTest.js
+++ b/test/contracts/timelockUpgradeTest.js
@@ -97,7 +97,7 @@ describe('Polygon ZK-EVM', () => {
         });
 
         // deploy PolygonZkEVMBridge
-        const polygonZkEVMBridgeFactory = await ethers.getContractFactory('PolygonZkEVMBridge');
+        const polygonZkEVMBridgeFactory = await ethers.getContractFactory('PolygonZkEVMBridgeWrapper');
         polygonZkEVMBridgeContract = await upgrades.deployProxy(polygonZkEVMBridgeFactory, [], { initializer: false });
 
         // deploy PolygonZkEVMMock


### PR DESCRIPTION
The only change needed is to change the modifier "initialier" to "OnlyInitialing" to properly inherit and call the initializing function from the parent contract.

The rest of the PR is cosmetics and making tests pass.