### PR TITLE
dont' do docker builds on main, only on tags

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -5,7 +5,10 @@ name: Build-Docker image
 
 on:
   push:
-    branches: [main]
+    # Pattern matched against refs/tags
+    tags:        
+      - '*'
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
(this would only waste of CI capa), since we don't use the docker images right now