### PR TITLE
removing the constructor

### DIFF
--- a/contracts/PolygonZkEVM.sol
+++ b/contracts/PolygonZkEVM.sol
@@ -145,22 +145,22 @@ contract PolygonZkEVM is
     uint256 internal constant _MAX_UINT_64 = type(uint64).max; // 0xFFFFFFFFFFFFFFFF
 
     // MATIC token address
-    IERC20Upgradeable public immutable matic;
+    IERC20Upgradeable public  matic;
 
     // Rollup verifier interface
-    IVerifierRollup public immutable rollupVerifier;
+    IVerifierRollup public  rollupVerifier;
 
     // Global Exit Root interface
-    IPolygonZkEVMGlobalExitRoot public immutable globalExitRootManager;
+    IPolygonZkEVMGlobalExitRoot public  globalExitRootManager;
 
     // PolygonZkEVM Bridge Address
-    IPolygonZkEVMBridge public immutable bridgeAddress;
+    IPolygonZkEVMBridge public  bridgeAddress;
 
     // L2 chain identifier
-    uint64 public immutable chainID;
+    uint64 public  chainID;
 
     // L2 chain identifier
-    uint64 public immutable forkID;
+    uint64 public  forkID;
 
     // Time target of the verification of a batch
     // Adaptatly the batchFee will be updated to achieve this target
@@ -368,6 +368,10 @@ contract PolygonZkEVM is
     event UpdateZkEVMVersion(uint64 numBatch, uint64 forkID, string version);
 
     /**
+     * @param initializePackedParameters Struct to save gas and avoid stack too deep errors
+     * @param genesisRoot Rollup genesis root
+     * @param _trustedSequencerURL Trusted sequencer URL
+     * @param _networkName L2 network name
      * @param _globalExitRootManager Global exit root manager address
      * @param _matic MATIC token address
      * @param _rollupVerifier Rollup verifier address
@@ -375,35 +379,25 @@ contract PolygonZkEVM is
      * @param _chainID L2 chainID
      * @param _forkID Fork Id
      */
-    constructor(
+    function initialize(
+        InitializePackedParameters calldata initializePackedParameters,
+        bytes32 genesisRoot,
+        string memory _trustedSequencerURL,
+        string memory _networkName,
+        string calldata _version,
         IPolygonZkEVMGlobalExitRoot _globalExitRootManager,
         IERC20Upgradeable _matic,
         IVerifierRollup _rollupVerifier,
         IPolygonZkEVMBridge _bridgeAddress,
         uint64 _chainID,
         uint64 _forkID
-    ) {
+    ) external initializer {
         globalExitRootManager = _globalExitRootManager;
         matic = _matic;
         rollupVerifier = _rollupVerifier;
         bridgeAddress = _bridgeAddress;
         chainID = _chainID;
         forkID = _forkID;
-    }
-
-    /**
-     * @param initializePackedParameters Struct to save gas and avoid stack too deep errors
-     * @param genesisRoot Rollup genesis root
-     * @param _trustedSequencerURL Trusted sequencer URL
-     * @param _networkName L2 network name
-     */
-    function initialize(
-        InitializePackedParameters calldata initializePackedParameters,
-        bytes32 genesisRoot,
-        string memory _trustedSequencerURL,
-        string memory _networkName,
-        string calldata _version
-    ) external initializer {
         admin = initializePackedParameters.admin;
         trustedSequencer = initializePackedParameters.trustedSequencer;
         trustedAggregator = initializePackedParameters.trustedAggregator;

--- a/contracts/mocks/PolygonZkEVMMock.sol
+++ b/contracts/mocks/PolygonZkEVMMock.sol
@@ -10,30 +10,6 @@ import "../PolygonZkEVM.sol";
  * To enter and exit of the L2 network will be used a PolygonZkEVM Bridge smart contract
  */
 contract PolygonZkEVMMock is PolygonZkEVM {
-    /**
-     * @param _globalExitRootManager Global exit root manager address
-     * @param _matic MATIC token address
-     * @param _rollupVerifier Rollup verifier address
-     * @param _bridgeAddress Bridge address
-     * @param _chainID L2 chainID
-     */
-    constructor(
-        IPolygonZkEVMGlobalExitRoot _globalExitRootManager,
-        IERC20Upgradeable _matic,
-        IVerifierRollup _rollupVerifier,
-        IPolygonZkEVMBridge _bridgeAddress,
-        uint64 _chainID,
-        uint64 _forkID
-    )
-        PolygonZkEVM(
-            _globalExitRootManager,
-            _matic,
-            _rollupVerifier,
-            _bridgeAddress,
-            _chainID,
-            _forkID
-        )
-    {}
 
     /**
      * @notice calculate accumulate input hash from parameters

--- a/contracts/testnet/PolygonZkEVMTestnetClearStorage.sol
+++ b/contracts/testnet/PolygonZkEVMTestnetClearStorage.sol
@@ -12,31 +12,6 @@ contract PolygonZkEVMTestnetClearStorage is PolygonZkEVM {
     uint256 public version;
 
     /**
-     * @param _globalExitRootManager Global exit root manager address
-     * @param _matic MATIC token address
-     * @param _rollupVerifier Rollup verifier address
-     * @param _bridgeAddress Bridge address
-     * @param _chainID L2 chainID
-     */
-    constructor(
-        IPolygonZkEVMGlobalExitRoot _globalExitRootManager,
-        IERC20Upgradeable _matic,
-        IVerifierRollup _rollupVerifier,
-        IPolygonZkEVMBridge _bridgeAddress,
-        uint64 _chainID,
-        uint64 _forkID
-    )
-        PolygonZkEVM(
-            _globalExitRootManager,
-            _matic,
-            _rollupVerifier,
-            _bridgeAddress,
-            _chainID,
-            _forkID
-        )
-    {}
-
-    /**
      * @dev Thrown when try to update version when it's already updated
      */
     error VersionAlreadyUpdated();

--- a/contracts/testnet/PolygonZkEVMTestnetV2.sol
+++ b/contracts/testnet/PolygonZkEVMTestnetV2.sol
@@ -12,31 +12,6 @@ contract PolygonZkEVMTestnetV2 is PolygonZkEVM {
     uint256 public version;
 
     /**
-     * @param _globalExitRootManager Global exit root manager address
-     * @param _matic MATIC token address
-     * @param _rollupVerifier Rollup verifier address
-     * @param _bridgeAddress Bridge address
-     * @param _chainID L2 chainID
-     */
-    constructor(
-        IPolygonZkEVMGlobalExitRoot _globalExitRootManager,
-        IERC20Upgradeable _matic,
-        IVerifierRollup _rollupVerifier,
-        IPolygonZkEVMBridge _bridgeAddress,
-        uint64 _chainID,
-        uint64 _forkID
-    )
-        PolygonZkEVM(
-            _globalExitRootManager,
-            _matic,
-            _rollupVerifier,
-            _bridgeAddress,
-            _chainID,
-            _forkID
-        )
-    {}
-
-    /**
      * @dev Thrown when try to update version when it's already updated
      */
     error VersionAlreadyUpdated();

--- a/deployment/3_deployContracts.js
+++ b/deployment/3_deployContracts.js
@@ -370,16 +370,15 @@ async function main() {
                         trustedSequencerURL,
                         networkName,
                         version,
+                        polygonZkEVMGlobalExitRoot.address,
+                        maticTokenAddress,
+                        verifierContract.address,
+                        polygonZkEVMBridgeContract.address,
+                        chainID,
+                        forkID,
                     ],
                     {
-                        constructorArgs: [
-                            polygonZkEVMGlobalExitRoot.address,
-                            maticTokenAddress,
-                            verifierContract.address,
-                            polygonZkEVMBridgeContract.address,
-                            chainID,
-                            forkID,
-                        ],
+                        constructorArgs: [],
                         unsafeAllow: ['constructor', 'state-variable-immutable'],
                     },
                 );

--- a/test/contracts/emergencyManager.test.js
+++ b/test/contracts/emergencyManager.test.js
@@ -81,14 +81,7 @@ describe('Emergency mode test', () => {
         const PolygonZkEVMFactory = await ethers.getContractFactory('PolygonZkEVMMock');
         polygonZkEVMContract = await upgrades.deployProxy(PolygonZkEVMFactory, [], {
             initializer: false,
-            constructorArgs: [
-                polygonZkEVMGlobalExitRoot.address,
-                maticTokenContract.address,
-                verifierContract.address,
-                polygonZkEVMBridgeContract.address,
-                chainID,
-                0,
-            ],
+            constructorArgs: [],
             unsafeAllow: ['constructor', 'state-variable-immutable'],
         });
 
@@ -108,6 +101,12 @@ describe('Emergency mode test', () => {
             urlSequencer,
             networkName,
             version,
+            polygonZkEVMGlobalExitRoot.address,
+            maticTokenContract.address,
+            verifierContract.address,
+            polygonZkEVMBridgeContract.address,
+            chainID,
+            0,
         );
 
         // fund sequencer address with Matic tokens

--- a/test/contracts/polygonZkEVM.test.js
+++ b/test/contracts/polygonZkEVM.test.js
@@ -70,8 +70,8 @@ describe('Polygon ZK-EVM', () => {
         if ((await upgrades.admin.getInstance()).address !== '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0') {
             firstDeployment = false;
         }
-        const nonceProxyBridge = Number((await ethers.provider.getTransactionCount(deployer.address))) + (firstDeployment ? 3 : 2);
-        const nonceProxyZkevm = nonceProxyBridge + 2; // Always have to redeploy impl since the polygonZkEVMGlobalExitRoot address changes
+        const nonceProxyBridge = Number((await ethers.provider.getTransactionCount(deployer.address))) + (firstDeployment ? 2 : 2);
+        const nonceProxyZkevm = nonceProxyBridge + 1; // Always have to redeploy impl since the polygonZkEVMGlobalExitRoot address changes
 
         const precalculateBridgeAddress = ethers.utils.getContractAddress({ from: deployer.address, nonce: nonceProxyBridge });
         const precalculateZkevmAddress = ethers.utils.getContractAddress({ from: deployer.address, nonce: nonceProxyZkevm });
@@ -92,17 +92,9 @@ describe('Polygon ZK-EVM', () => {
         const PolygonZkEVMFactory = await ethers.getContractFactory('PolygonZkEVMMock');
         polygonZkEVMContract = await upgrades.deployProxy(PolygonZkEVMFactory, [], {
             initializer: false,
-            constructorArgs: [
-                polygonZkEVMGlobalExitRoot.address,
-                maticTokenContract.address,
-                verifierContract.address,
-                polygonZkEVMBridgeContract.address,
-                chainID,
-                forkID,
-            ],
+            constructorArgs: [],
             unsafeAllow: ['constructor', 'state-variable-immutable'],
         });
-
         expect(precalculateBridgeAddress).to.be.equal(polygonZkEVMBridgeContract.address);
         expect(precalculateZkevmAddress).to.be.equal(polygonZkEVMContract.address);
 
@@ -119,6 +111,12 @@ describe('Polygon ZK-EVM', () => {
             urlSequencer,
             networkName,
             version,
+            polygonZkEVMGlobalExitRoot.address,
+            maticTokenContract.address,
+            verifierContract.address,
+            polygonZkEVMBridgeContract.address,
+            chainID,
+            forkID,
         );
 
         // fund sequencer address with Matic tokens
@@ -156,12 +154,7 @@ describe('Polygon ZK-EVM', () => {
         const polygonZkEVMContractInitialize = await upgrades.deployProxy(PolygonZkEVMFactory, [], {
             initializer: false,
             constructorArgs: [
-                polygonZkEVMGlobalExitRoot.address,
-                maticTokenContract.address,
-                verifierContract.address,
-                polygonZkEVMBridgeContract.address,
-                chainID,
-                forkID,
+
             ],
             unsafeAllow: ['constructor', 'state-variable-immutable'],
         });
@@ -178,6 +171,12 @@ describe('Polygon ZK-EVM', () => {
             urlSequencer,
             networkName,
             version,
+            polygonZkEVMGlobalExitRoot.address,
+            maticTokenContract.address,
+            verifierContract.address,
+            polygonZkEVMBridgeContract.address,
+            chainID,
+            forkID,
         )).to.be.revertedWith('PendingStateTimeoutExceedHaltAggregationTimeout');
 
         await expect(polygonZkEVMContractInitialize.initialize(
@@ -192,6 +191,12 @@ describe('Polygon ZK-EVM', () => {
             urlSequencer,
             networkName,
             version,
+            polygonZkEVMGlobalExitRoot.address,
+            maticTokenContract.address,
+            verifierContract.address,
+            polygonZkEVMBridgeContract.address,
+            chainID,
+            forkID,
         )).to.be.revertedWith('TrustedAggregatorTimeoutExceedHaltAggregationTimeout');
 
         await expect(
@@ -207,6 +212,12 @@ describe('Polygon ZK-EVM', () => {
                 urlSequencer,
                 networkName,
                 version,
+                polygonZkEVMGlobalExitRoot.address,
+                maticTokenContract.address,
+                verifierContract.address,
+                polygonZkEVMBridgeContract.address,
+                chainID,
+                forkID,
             ),
         ).to.emit(polygonZkEVMContractInitialize, 'UpdateZkEVMVersion').withArgs(0, forkID, version);
     });

--- a/test/contracts/polygonZkEVM.test.js
+++ b/test/contracts/polygonZkEVM.test.js
@@ -70,8 +70,8 @@ describe('Polygon ZK-EVM', () => {
         if ((await upgrades.admin.getInstance()).address !== '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0') {
             firstDeployment = false;
         }
-        const nonceProxyBridge = Number((await ethers.provider.getTransactionCount(deployer.address))) + (firstDeployment ? 2 : 2);
-        const nonceProxyZkevm = nonceProxyBridge + 1; // Always have to redeploy impl since the polygonZkEVMGlobalExitRoot address changes
+        const nonceProxyBridge = Number((await ethers.provider.getTransactionCount(deployer.address))) + (firstDeployment ? 3 : 2);
+        const nonceProxyZkevm = nonceProxyBridge + (firstDeployment ? 2 : 1); // Always have to redeploy impl since the polygonZkEVMGlobalExitRoot address changes
 
         const precalculateBridgeAddress = ethers.utils.getContractAddress({ from: deployer.address, nonce: nonceProxyBridge });
         const precalculateZkevmAddress = ethers.utils.getContractAddress({ from: deployer.address, nonce: nonceProxyZkevm });

--- a/test/contracts/polygonZkEVM.test.js
+++ b/test/contracts/polygonZkEVM.test.js
@@ -71,7 +71,7 @@ describe('Polygon ZK-EVM', () => {
             firstDeployment = false;
         }
         const nonceProxyBridge = Number((await ethers.provider.getTransactionCount(deployer.address))) + (firstDeployment ? 3 : 2);
-        const nonceProxyZkevm = nonceProxyBridge + (firstDeployment ? 2 : 1); // Always have to redeploy impl since the polygonZkEVMGlobalExitRoot address changes
+        const nonceProxyZkevm = nonceProxyBridge + (firstDeployment ? 2 : 1);
 
         const precalculateBridgeAddress = ethers.utils.getContractAddress({ from: deployer.address, nonce: nonceProxyBridge });
         const precalculateZkevmAddress = ethers.utils.getContractAddress({ from: deployer.address, nonce: nonceProxyZkevm });

--- a/test/contracts/polygonZkEVMTestnetV2.test.js
+++ b/test/contracts/polygonZkEVMTestnetV2.test.js
@@ -57,12 +57,12 @@ describe('Polygon ZK-EVM TestnetV2', () => {
          * In order to not have trouble with nonce deploy first proxy admin
          */
         await upgrades.deployProxyAdmin();
-        if ((await upgrades.admin.getInstance()).address !== '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0') {
+        if ((await upgrades.admin.getInstance()).address !== '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512') {
             firstDeployment = false;
         }
-        const nonceProxyBridge = Number((await ethers.provider.getTransactionCount(deployer.address))) + (firstDeployment ? 3 : 2);
-        const nonceProxyZkevm = nonceProxyBridge + 2; // Always have to redeploy impl since the polygonZkEVMGlobalExitRoot address changes
-
+        const nonceProxyBridge = Number((await ethers.provider.getTransactionCount(deployer.address))) + (firstDeployment ? 2 : 2);
+        // Always have to redeploy impl since the polygonZkEVMGlobalExitRoot address changes
+        const nonceProxyZkevm = nonceProxyBridge + +(firstDeployment ? 2 : 1);
         const precalculateBridgeAddress = ethers.utils.getContractAddress({ from: deployer.address, nonce: nonceProxyBridge });
         const precalculateZkevmAddress = ethers.utils.getContractAddress({ from: deployer.address, nonce: nonceProxyZkevm });
         firstDeployment = false;
@@ -82,14 +82,7 @@ describe('Polygon ZK-EVM TestnetV2', () => {
         const PolygonZkEVMFactory = await ethers.getContractFactory('PolygonZkEVMTestnetV2');
         polygonZkEVMContract = await upgrades.deployProxy(PolygonZkEVMFactory, [], {
             initializer: false,
-            constructorArgs: [
-                polygonZkEVMGlobalExitRoot.address,
-                maticTokenContract.address,
-                verifierContract.address,
-                polygonZkEVMBridgeContract.address,
-                chainID,
-                forkID,
-            ],
+            constructorArgs: [],
             unsafeAllow: ['constructor', 'state-variable-immutable'],
         });
 
@@ -109,6 +102,12 @@ describe('Polygon ZK-EVM TestnetV2', () => {
             urlSequencer,
             networkName,
             version,
+            polygonZkEVMGlobalExitRoot.address,
+            maticTokenContract.address,
+            verifierContract.address,
+            polygonZkEVMBridgeContract.address,
+            chainID,
+            forkID,
         );
 
         // fund sequencer address with Matic tokens

--- a/test/contracts/polygonZkEVMTestnetV2.test.js
+++ b/test/contracts/polygonZkEVMTestnetV2.test.js
@@ -29,6 +29,7 @@ describe('Polygon ZK-EVM TestnetV2', () => {
     const pendingStateTimeoutDefault = 100;
     const trustedAggregatorTimeoutDefault = 10;
     let firstDeployment = true;
+    let doesNeedImplementationDeployment = true;
 
     beforeEach('Deploy contract', async () => {
         upgrades.silenceWarnings();
@@ -57,16 +58,15 @@ describe('Polygon ZK-EVM TestnetV2', () => {
          * In order to not have trouble with nonce deploy first proxy admin
          */
         await upgrades.deployProxyAdmin();
-        if ((await upgrades.admin.getInstance()).address !== '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512') {
+        if ((await upgrades.admin.getInstance()).address !== '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0') {
             firstDeployment = false;
         }
-        const nonceProxyBridge = Number((await ethers.provider.getTransactionCount(deployer.address))) + (firstDeployment ? 2 : 2);
-        // Always have to redeploy impl since the polygonZkEVMGlobalExitRoot address changes
-        const nonceProxyZkevm = nonceProxyBridge + +(firstDeployment ? 2 : 1);
+        const nonceProxyBridge = Number((await ethers.provider.getTransactionCount(deployer.address))) +  (firstDeployment ? 3 : 2);
+        const nonceProxyZkevm = nonceProxyBridge + (doesNeedImplementationDeployment ? 2 : 1);
         const precalculateBridgeAddress = ethers.utils.getContractAddress({ from: deployer.address, nonce: nonceProxyBridge });
         const precalculateZkevmAddress = ethers.utils.getContractAddress({ from: deployer.address, nonce: nonceProxyZkevm });
         firstDeployment = false;
-
+        doesNeedImplementationDeployment = false;
         const PolygonZkEVMGlobalExitRootFactory = await ethers.getContractFactory('PolygonZkEVMGlobalExitRoot');
         polygonZkEVMGlobalExitRoot = await upgrades.deployProxy(PolygonZkEVMGlobalExitRootFactory, [], {
             initializer: false,

--- a/test/contracts/polygonZkEVMTestnetV2.test.js
+++ b/test/contracts/polygonZkEVMTestnetV2.test.js
@@ -61,7 +61,7 @@ describe('Polygon ZK-EVM TestnetV2', () => {
         if ((await upgrades.admin.getInstance()).address !== '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0') {
             firstDeployment = false;
         }
-        const nonceProxyBridge = Number((await ethers.provider.getTransactionCount(deployer.address))) +  (firstDeployment ? 3 : 2);
+        const nonceProxyBridge = Number((await ethers.provider.getTransactionCount(deployer.address))) + (firstDeployment ? 3 : 2);
         const nonceProxyZkevm = nonceProxyBridge + (doesNeedImplementationDeployment ? 2 : 1);
         const precalculateBridgeAddress = ethers.utils.getContractAddress({ from: deployer.address, nonce: nonceProxyBridge });
         const precalculateZkevmAddress = ethers.utils.getContractAddress({ from: deployer.address, nonce: nonceProxyZkevm });

--- a/test/contracts/snark_stark_input.test.js
+++ b/test/contracts/snark_stark_input.test.js
@@ -23,14 +23,7 @@ describe('Polygon ZK-EVM snark stark input test', () => {
         const PolygonZkEVMFactory = await ethers.getContractFactory('PolygonZkEVMMock');
         polygonZkEVMContract = await upgrades.deployProxy(PolygonZkEVMFactory, [], {
             initializer: false,
-            constructorArgs: [
-                randomSigner.address,
-                randomSigner.address,
-                randomSigner.address,
-                randomSigner.address,
-                chainID,
-                0,
-            ],
+            constructorArgs: [],
             unsafeAllow: ['constructor', 'state-variable-immutable'],
         });
 
@@ -46,6 +39,12 @@ describe('Polygon ZK-EVM snark stark input test', () => {
             urlSequencer,
             networkName,
             version,
+            randomSigner.address,
+            randomSigner.address,
+            randomSigner.address,
+            randomSigner.address,
+            chainID,
+            0,
         );
 
         await polygonZkEVMContract.deployed();


### PR DESCRIPTION
since the contracts need to be initialized with the open zepplin libraries, we remove the constructors and implement initialize function.