### PR TITLE
Allowing to specify another gas token than eth

### DIFF
--- a/contracts/PolygonZkEVMBridgeWrapper.sol
+++ b/contracts/PolygonZkEVMBridgeWrapper.sol
@@ -7,8 +7,10 @@ contract PolygonZkEVMBridgeWrapper is PolygonZkEVMBridge{
     function initialize(
         uint32 _networkID,
         IBasePolygonZkEVMGlobalExitRoot _globalExitRootManager,
-        address _polygonZkEVMaddress
+        address _polygonZkEVMaddress,
+        address _gasTokenAddress,
+        bool _isDeployedOnL2
     ) public virtual override initializer {
-        PolygonZkEVMBridge.initialize(_networkID, _globalExitRootManager, _polygonZkEVMaddress);
+        PolygonZkEVMBridge.initialize(_networkID, _globalExitRootManager, _polygonZkEVMaddress, _gasTokenAddress, _isDeployedOnL2);
     }
 }

--- a/contracts/mocks/PolygonZkEVMBridgeMock.sol
+++ b/contracts/mocks/PolygonZkEVMBridgeMock.sol
@@ -17,11 +17,15 @@ contract PolygonZkEVMBridgeMock is PolygonZkEVMBridgeWrapper, OwnableUpgradeable
     function initialize(
         uint32 _networkID,
         IBasePolygonZkEVMGlobalExitRoot _globalExitRootManager,
-        address _polygonZkEVMaddress
+        address _polygonZkEVMaddress,
+        address _gasTokenAddress,
+        bool _isDeployedOnL2
     ) public override initializer {
         networkID = _networkID;
         globalExitRootManager = _globalExitRootManager;
         polygonZkEVMaddress = _polygonZkEVMaddress;
+        gasTokenAddress = _gasTokenAddress;
+        isDeployedOnL2= _isDeployedOnL2;
 
         maxEtherBridge = 0.25 ether;
 

--- a/test/contracts/bridgeMock.test.js
+++ b/test/contracts/bridgeMock.test.js
@@ -18,6 +18,7 @@ describe('PolygonZkEVMBridge Mock Contract', () => {
     let polygonZkEVMGlobalExitRoot;
     let polygonZkEVMBridgeContract;
     let tokenContract;
+    let gasTokenContract;
 
     const tokenName = 'Matic Token';
     const tokenSymbol = 'MATIC';
@@ -27,7 +28,8 @@ describe('PolygonZkEVMBridge Mock Contract', () => {
         ['string', 'string', 'uint8'],
         [tokenName, tokenSymbol, decimals],
     );
-
+    const gasTokenName = 'Fork Token';
+    const gasTokenSymbol = 'FORK';
     const networkIDMainnet = 0;
     const networkIDRollup = 1;
 
@@ -38,6 +40,16 @@ describe('PolygonZkEVMBridge Mock Contract', () => {
         // load signers
         [deployer, rollup, acc1] = await ethers.getSigners();
 
+        // deploy gas token
+        const gasTokenFactory = await ethers.getContractFactory('ERC20PermitMock');
+        gasTokenContract = await gasTokenFactory.deploy(
+            gasTokenName,
+            gasTokenSymbol,
+            deployer.address,
+            tokenInitialBalance,
+        );
+        await gasTokenContract.deployed();
+
         // deploy global exit root manager
         const PolygonZkEVMGlobalExitRootFactory = await ethers.getContractFactory('PolygonZkEVMGlobalExitRootMock');
 
@@ -46,7 +58,13 @@ describe('PolygonZkEVMBridge Mock Contract', () => {
         polygonZkEVMBridgeContract = await upgrades.deployProxy(polygonZkEVMBridgeFactory, [], { initializer: false });
 
         polygonZkEVMGlobalExitRoot = await PolygonZkEVMGlobalExitRootFactory.deploy(rollup.address, polygonZkEVMBridgeContract.address);
-        await polygonZkEVMBridgeContract.initialize(networkIDMainnet, polygonZkEVMGlobalExitRoot.address, polygonZkEVMAddress);
+        await polygonZkEVMBridgeContract.initialize(
+            networkIDMainnet,
+            polygonZkEVMGlobalExitRoot.address,
+            polygonZkEVMAddress,
+            gasTokenContract.address,
+            true,
+        );
 
         // deploy token
         const maticTokenFactory = await ethers.getContractFactory('ERC20PermitMock');


### PR DESCRIPTION
Allows to specify another gas token. It's similar to the methods suggested here: https://github.com/0xPolygonHermez/zkevm-contracts/issues/123#issuecomment-1622690216, 
but we don't allow eth deposits.