### PR TITLE
Initalize gloabl exit root without constructor

### DIFF
--- a/contracts/PolygonZkEVMGlobalExitRootWrapper.sol
+++ b/contracts/PolygonZkEVMGlobalExitRootWrapper.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0
+
+pragma solidity 0.8.17;
+
+import "./interfaces/IPolygonZkEVMGlobalExitRoot.sol";
+import "./inheritedMainContracts/PolygonZkEVMGlobalExitRoot.sol";
+
+contract PolygonZkEVMGlobalExitRootWrapper is PolygonZkEVMGlobalExitRoot {
+    /**
+     * @param _rollupAddress Rollup contract address
+     * @param _bridgeAddress PolygonZkEVMBridge contract address
+     */
+    function initialize(address _rollupAddress, address _bridgeAddress) public override initializer {
+        PolygonZkEVMGlobalExitRoot.initialize(_rollupAddress, _bridgeAddress);
+    }
+}
+    

--- a/contracts/inheritedMainContracts/PolygonZkEVMGlobalExitRoot.sol
+++ b/contracts/inheritedMainContracts/PolygonZkEVMGlobalExitRoot.sol
@@ -2,18 +2,19 @@
 
 pragma solidity 0.8.17;
 
-import "./interfaces/IPolygonZkEVMGlobalExitRoot.sol";
-import "./lib/GlobalExitRootLib.sol";
+import "../interfaces/IPolygonZkEVMGlobalExitRoot.sol";
+import "../lib/GlobalExitRootLib.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 /**
  * Contract responsible for managing the exit roots across multiple networks
  */
-contract PolygonZkEVMGlobalExitRoot is IPolygonZkEVMGlobalExitRoot {
+contract PolygonZkEVMGlobalExitRoot is IPolygonZkEVMGlobalExitRoot, Initializable {
     // PolygonZkEVMBridge address
-    address public immutable bridgeAddress;
+    address public bridgeAddress;
 
     // Rollup contract address
-    address public immutable rollupAddress;
+    address public rollupAddress;
 
     // Rollup exit root, this will be updated every time a batch is verified
     bytes32 public lastRollupExitRoot;
@@ -36,7 +37,7 @@ contract PolygonZkEVMGlobalExitRoot is IPolygonZkEVMGlobalExitRoot {
      * @param _rollupAddress Rollup contract address
      * @param _bridgeAddress PolygonZkEVMBridge contract address
      */
-    constructor(address _rollupAddress, address _bridgeAddress) {
+    function initialize(address _rollupAddress, address _bridgeAddress) public virtual onlyInitializing {
         rollupAddress = _rollupAddress;
         bridgeAddress = _bridgeAddress;
     }

--- a/contracts/mocks/PolygonZkEVMGlobalExitRootMock.sol
+++ b/contracts/mocks/PolygonZkEVMGlobalExitRootMock.sol
@@ -1,21 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity 0.8.17;
 
-import "../PolygonZkEVMGlobalExitRoot.sol";
+import "../PolygonZkEVMGlobalExitRootWrapper.sol";
 
 /**
  * Contract responsible for managing the exit roots across multiple networks
 
  */
-contract PolygonZkEVMGlobalExitRootMock is PolygonZkEVMGlobalExitRoot {
-    /**
-     * @param _rollupAddress Rollup contract address
-     * @param _bridgeAddress PolygonZkEVM Bridge contract address
-     */
-    constructor(
-        address _rollupAddress,
-        address _bridgeAddress
-    ) PolygonZkEVMGlobalExitRoot(_rollupAddress, _bridgeAddress) {}
+contract PolygonZkEVMGlobalExitRootMock is PolygonZkEVMGlobalExitRootWrapper {
 
     /**
      * @notice Set last global exit root

--- a/test/contracts/bridge.test.js
+++ b/test/contracts/bridge.test.js
@@ -61,8 +61,10 @@ describe('PolygonZkEVMBridge Contract - for L2', () => {
         polygonZkEVMBridgeContract = await upgrades.deployProxy(polygonZkEVMBridgeFactory, [], { initializer: false });
 
         // deploy global exit root manager
-        const PolygonZkEVMGlobalExitRootFactory = await ethers.getContractFactory('PolygonZkEVMGlobalExitRoot');
-        polygonZkEVMGlobalExitRoot = await PolygonZkEVMGlobalExitRootFactory.deploy(rollup.address, polygonZkEVMBridgeContract.address);
+        const PolygonZkEVMGlobalExitRootFactory = await ethers.getContractFactory('PolygonZkEVMGlobalExitRootWrapper');
+        polygonZkEVMGlobalExitRoot = await upgrades.deployProxy(PolygonZkEVMGlobalExitRootFactory, [], { initializer: false });
+
+        await polygonZkEVMGlobalExitRoot.initialize(rollup.address, polygonZkEVMBridgeContract.address);
 
         await polygonZkEVMBridgeContract.initialize(
             networkIDMainnet,
@@ -1219,8 +1221,10 @@ describe('PolygonZkEVMBridge Contract - for L1', () => {
         polygonZkEVMBridgeContract = await upgrades.deployProxy(polygonZkEVMBridgeFactory, [], { initializer: false });
 
         // deploy global exit root manager
-        const PolygonZkEVMGlobalExitRootFactory = await ethers.getContractFactory('PolygonZkEVMGlobalExitRoot');
-        polygonZkEVMGlobalExitRoot = await PolygonZkEVMGlobalExitRootFactory.deploy(rollup.address, polygonZkEVMBridgeContract.address);
+        const PolygonZkEVMGlobalExitRootFactory = await ethers.getContractFactory('PolygonZkEVMGlobalExitRootWrapper');
+        polygonZkEVMGlobalExitRoot = await upgrades.deployProxy(PolygonZkEVMGlobalExitRootFactory, [], { initializer: false });
+
+        await polygonZkEVMGlobalExitRoot.initialize(rollup.address, polygonZkEVMBridgeContract.address);
 
         await polygonZkEVMBridgeContract.initialize(
             networkIDMainnet,

--- a/test/contracts/bridgeMock.test.js
+++ b/test/contracts/bridgeMock.test.js
@@ -50,14 +50,16 @@ describe('PolygonZkEVMBridge Mock Contract', () => {
         );
         await gasTokenContract.deployed();
 
-        // deploy global exit root manager
-        const PolygonZkEVMGlobalExitRootFactory = await ethers.getContractFactory('PolygonZkEVMGlobalExitRootMock');
-
         // deploy PolygonZkEVMBridge
         const polygonZkEVMBridgeFactory = await ethers.getContractFactory('PolygonZkEVMBridgeMock');
         polygonZkEVMBridgeContract = await upgrades.deployProxy(polygonZkEVMBridgeFactory, [], { initializer: false });
 
-        polygonZkEVMGlobalExitRoot = await PolygonZkEVMGlobalExitRootFactory.deploy(rollup.address, polygonZkEVMBridgeContract.address);
+
+        // deploy global exit root manager
+        const polygonZkEVMGlobalExitRootFactory = await ethers.getContractFactory('PolygonZkEVMGlobalExitRootMock');
+        polygonZkEVMGlobalExitRoot = await upgrades.deployProxy(polygonZkEVMGlobalExitRootFactory, [], { initializer: false });
+        await polygonZkEVMGlobalExitRoot.initialize(rollup.address, polygonZkEVMBridgeContract.address);
+
         await polygonZkEVMBridgeContract.initialize(
             networkIDMainnet,
             polygonZkEVMGlobalExitRoot.address,

--- a/test/contracts/bridgeMock.test.js
+++ b/test/contracts/bridgeMock.test.js
@@ -54,7 +54,6 @@ describe('PolygonZkEVMBridge Mock Contract', () => {
         const polygonZkEVMBridgeFactory = await ethers.getContractFactory('PolygonZkEVMBridgeMock');
         polygonZkEVMBridgeContract = await upgrades.deployProxy(polygonZkEVMBridgeFactory, [], { initializer: false });
 
-
         // deploy global exit root manager
         const polygonZkEVMGlobalExitRootFactory = await ethers.getContractFactory('PolygonZkEVMGlobalExitRootMock');
         polygonZkEVMGlobalExitRoot = await upgrades.deployProxy(polygonZkEVMGlobalExitRootFactory, [], { initializer: false });

--- a/test/contracts/bridge_metadata.test.js
+++ b/test/contracts/bridge_metadata.test.js
@@ -44,12 +44,12 @@ describe('PolygonZkEVMBridge Contract werid metadata', () => {
         // deploy PolygonZkEVMBridge
         const polygonZkEVMBridgeFactory = await ethers.getContractFactory('PolygonZkEVMBridgeWrapper');
         polygonZkEVMBridgeContract = await upgrades.deployProxy(polygonZkEVMBridgeFactory, [], { initializer: false });
-        
+
         // deploy global exit root manager
         const polygonZkEVMGlobalExitRootFactory = await ethers.getContractFactory('PolygonZkEVMGlobalExitRootWrapper');
         polygonZkEVMGlobalExitRoot = await upgrades.deployProxy(polygonZkEVMGlobalExitRootFactory, [], { initializer: false });
         await polygonZkEVMGlobalExitRoot.initialize(rollup.address, polygonZkEVMBridgeContract.address);
-        
+
         await polygonZkEVMBridgeContract.initialize(
             networkIDMainnet,
             polygonZkEVMGlobalExitRoot.address,

--- a/test/contracts/bridge_metadata.test.js
+++ b/test/contracts/bridge_metadata.test.js
@@ -44,11 +44,12 @@ describe('PolygonZkEVMBridge Contract werid metadata', () => {
         // deploy PolygonZkEVMBridge
         const polygonZkEVMBridgeFactory = await ethers.getContractFactory('PolygonZkEVMBridgeWrapper');
         polygonZkEVMBridgeContract = await upgrades.deployProxy(polygonZkEVMBridgeFactory, [], { initializer: false });
-
+        
         // deploy global exit root manager
-        const polygonZkEVMGlobalExitRootFactory = await ethers.getContractFactory('PolygonZkEVMGlobalExitRoot');
-        polygonZkEVMGlobalExitRoot = await polygonZkEVMGlobalExitRootFactory.deploy(rollup.address, polygonZkEVMBridgeContract.address);
-
+        const polygonZkEVMGlobalExitRootFactory = await ethers.getContractFactory('PolygonZkEVMGlobalExitRootWrapper');
+        polygonZkEVMGlobalExitRoot = await upgrades.deployProxy(polygonZkEVMGlobalExitRootFactory, [], { initializer: false });
+        await polygonZkEVMGlobalExitRoot.initialize(rollup.address, polygonZkEVMBridgeContract.address);
+        
         await polygonZkEVMBridgeContract.initialize(
             networkIDMainnet,
             polygonZkEVMGlobalExitRoot.address,

--- a/test/contracts/bridge_permit.test.js
+++ b/test/contracts/bridge_permit.test.js
@@ -64,8 +64,9 @@ describe('PolygonZkEVMBridge Contract Permit tests', () => {
         polygonZkEVMBridgeContract = await upgrades.deployProxy(polygonZkEVMBridgeFactory, [], { initializer: false });
 
         // deploy global exit root manager
-        const polygonZkEVMGlobalExitRootFactory = await ethers.getContractFactory('PolygonZkEVMGlobalExitRoot');
-        polygonZkEVMGlobalExitRoot = await polygonZkEVMGlobalExitRootFactory.deploy(rollup.address, polygonZkEVMBridgeContract.address);
+        const polygonZkEVMGlobalExitRootFactory = await ethers.getContractFactory('PolygonZkEVMGlobalExitRootWrapper');
+        polygonZkEVMGlobalExitRoot = await upgrades.deployProxy(polygonZkEVMGlobalExitRootFactory, [], { initializer: false });
+        await polygonZkEVMGlobalExitRoot.initialize(rollup.address, polygonZkEVMBridgeContract.address);
 
         await polygonZkEVMBridgeContract.initialize(
             networkIDMainnet,

--- a/test/contracts/emergencyManager.test.js
+++ b/test/contracts/emergencyManager.test.js
@@ -81,12 +81,12 @@ describe('Emergency mode test', () => {
         const precalculateZkevmAddress = ethers.utils.getContractAddress({ from: deployer.address, nonce: nonceProxyZkevm });
         firstDeployment = false;
 
-        const PolygonZkEVMGlobalExitRootFactory = await ethers.getContractFactory('PolygonZkEVMGlobalExitRoot');
+        const PolygonZkEVMGlobalExitRootFactory = await ethers.getContractFactory('PolygonZkEVMGlobalExitRootWrapper');
         polygonZkEVMGlobalExitRoot = await upgrades.deployProxy(PolygonZkEVMGlobalExitRootFactory, [], {
             initializer: false,
-            constructorArgs: [precalculateZkevmAddress, precalculateBridgeAddress],
-            unsafeAllow: ['constructor', 'state-variable-immutable'],
+            constructorArgs: [],
         });
+        await polygonZkEVMGlobalExitRoot.initialize(precalculateZkevmAddress, precalculateBridgeAddress);
 
         // deploy PolygonZkEVMBridge
         const polygonZkEVMBridgeFactory = await ethers.getContractFactory('PolygonZkEVMBridgeWrapper');

--- a/test/contracts/globalExitRootManager.test.js
+++ b/test/contracts/globalExitRootManager.test.js
@@ -1,5 +1,5 @@
 const { expect } = require('chai');
-const { ethers } = require('hardhat');
+const { ethers, upgrades } = require('hardhat');
 
 function calculateGlobalExitRoot(mainnetExitRoot, rollupExitRoot) {
     return ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], [mainnetExitRoot, rollupExitRoot]);

--- a/test/contracts/globalExitRootManager.test.js
+++ b/test/contracts/globalExitRootManager.test.js
@@ -16,12 +16,10 @@ describe('Global Exit Root', () => {
         [, rollup, PolygonZkEVMBridge] = await ethers.getSigners();
 
         // deploy global exit root manager
-        const PolygonZkEVMGlobalExitRootFactory = await ethers.getContractFactory('PolygonZkEVMGlobalExitRoot');
+        const PolygonZkEVMGlobalExitRootFactory = await ethers.getContractFactory('PolygonZkEVMGlobalExitRootWrapper');
+        polygonZkEVMGlobalExitRoot = await upgrades.deployProxy(PolygonZkEVMGlobalExitRootFactory, [], { initializer: false });
 
-        polygonZkEVMGlobalExitRoot = await PolygonZkEVMGlobalExitRootFactory.deploy(
-            rollup.address,
-            PolygonZkEVMBridge.address,
-        );
+        await polygonZkEVMGlobalExitRoot.initialize(rollup.address, PolygonZkEVMBridge.address);
         await polygonZkEVMGlobalExitRoot.deployed();
     });
 

--- a/test/contracts/globalExitRootManagerL2.test.js
+++ b/test/contracts/globalExitRootManagerL2.test.js
@@ -15,6 +15,7 @@ describe('Global Exit Root L2', () => {
         // deploy global exit root manager
         const PolygonZkEVMGlobalExitRootFactory = await ethers.getContractFactory('PolygonZkEVMGlobalExitRootL2Mock', deployer);
         polygonZkEVMGlobalExitRoot = await PolygonZkEVMGlobalExitRootFactory.deploy(PolygonZkEVMBridge.address);
+        await polygonZkEVMGlobalExitRoot.deployed();
     });
 
     it('should check the constructor parameters', async () => {

--- a/test/contracts/polygonZkEVM.test.js
+++ b/test/contracts/polygonZkEVM.test.js
@@ -92,12 +92,12 @@ describe('Polygon ZK-EVM', () => {
         const precalculateZkevmAddress = ethers.utils.getContractAddress({ from: deployer.address, nonce: nonceProxyZkevm });
         firstDeployment = false;
 
-        const PolygonZkEVMGlobalExitRootFactory = await ethers.getContractFactory('PolygonZkEVMGlobalExitRoot');
+        const PolygonZkEVMGlobalExitRootFactory = await ethers.getContractFactory('PolygonZkEVMGlobalExitRootWrapper');
         polygonZkEVMGlobalExitRoot = await upgrades.deployProxy(PolygonZkEVMGlobalExitRootFactory, [], {
             initializer: false,
-            constructorArgs: [precalculateZkevmAddress, precalculateBridgeAddress],
-            unsafeAllow: ['constructor', 'state-variable-immutable'],
+            constructorArgs: [],
         });
+        await polygonZkEVMGlobalExitRoot.initialize(precalculateZkevmAddress, precalculateBridgeAddress);
 
         // deploy PolygonZkEVMBridge
         const polygonZkEVMBridgeFactory = await ethers.getContractFactory('PolygonZkEVMBridgeWrapper');

--- a/test/contracts/polygonZkEVMTestnetV2.test.js
+++ b/test/contracts/polygonZkEVMTestnetV2.test.js
@@ -83,13 +83,13 @@ describe('Polygon ZK-EVM TestnetV2', () => {
         const precalculateZkevmAddress = ethers.utils.getContractAddress({ from: deployer.address, nonce: nonceProxyZkevm });
         firstDeployment = false;
         doesNeedImplementationDeployment = false;
-        const PolygonZkEVMGlobalExitRootFactory = await ethers.getContractFactory('PolygonZkEVMGlobalExitRoot');
+        const PolygonZkEVMGlobalExitRootFactory = await ethers.getContractFactory('PolygonZkEVMGlobalExitRootWrapper');
         polygonZkEVMGlobalExitRoot = await upgrades.deployProxy(PolygonZkEVMGlobalExitRootFactory, [], {
             initializer: false,
-            constructorArgs: [precalculateZkevmAddress, precalculateBridgeAddress],
-            unsafeAllow: ['constructor', 'state-variable-immutable'],
+            constructorArgs: [],
         });
 
+        await polygonZkEVMGlobalExitRoot.initialize(precalculateZkevmAddress, precalculateBridgeAddress);
         // deploy PolygonZkEVMBridge
         const polygonZkEVMBridgeFactory = await ethers.getContractFactory('PolygonZkEVMBridgeWrapper');
         polygonZkEVMBridgeContract = await upgrades.deployProxy(polygonZkEVMBridgeFactory, [], { initializer: false });


### PR DESCRIPTION
Similar to the other PRs, we also need the initialization for the global exit root manager via the initializer.