### PR TITLE
Virtual state root appending

### DIFF
--- a/contracts/PolygonZkEVMWrapper.sol
+++ b/contracts/PolygonZkEVMWrapper.sol
@@ -27,4 +27,47 @@ contract PolygonZkEVMWrapper is PolygonZkEVM{
             _bridgeAddress
         );
     }
+    function verifyBatchesTrustedAggregator(
+        uint64 pendingStateNum,
+        uint64 initNumBatch,
+        uint64 finalNewBatch,
+        bytes32 newLocalExitRoot,
+        bytes32 newStateRoot,
+        bytes calldata proof
+    ) public override onlyTrustedAggregator {
+        PolygonZkEVM.verifyBatchesTrustedAggregator(
+            pendingStateNum,
+            initNumBatch,
+            finalNewBatch,
+            newLocalExitRoot,
+            newStateRoot,
+            proof
+        );
+    }
+    function sequenceBatches(
+        BatchData[] calldata batches,
+        address l2Coinbase
+    ) public override ifNotEmergencyState onlyTrustedSequencer {
+        PolygonZkEVM.sequenceBatches(
+            batches,
+            l2Coinbase
+        );
+    }
+    function verifyBatches(
+        uint64 pendingStateNum,
+        uint64 initNumBatch,
+        uint64 finalNewBatch,
+        bytes32 newLocalExitRoot,
+        bytes32 newStateRoot,
+        bytes calldata proof
+    ) public override ifNotEmergencyState {
+        PolygonZkEVM.verifyBatches(
+            pendingStateNum,
+            initNumBatch,
+            finalNewBatch,
+            newLocalExitRoot,
+            newStateRoot,
+            proof
+        );
+    }
 }

--- a/contracts/inheritedMainContracts/PolygonZkEVM.sol
+++ b/contracts/inheritedMainContracts/PolygonZkEVM.sol
@@ -460,7 +460,7 @@ contract PolygonZkEVM is
     function sequenceBatches(
         BatchData[] calldata batches,
         address l2Coinbase
-    ) external ifNotEmergencyState onlyTrustedSequencer {
+    ) public virtual ifNotEmergencyState onlyTrustedSequencer {
         uint256 batchesNum = batches.length;
         if (batchesNum == 0) {
             revert SequenceZeroBatches();
@@ -616,7 +616,7 @@ contract PolygonZkEVM is
         bytes32 newLocalExitRoot,
         bytes32 newStateRoot,
         bytes calldata proof
-    ) external ifNotEmergencyState {
+    ) public virtual ifNotEmergencyState {
         // Check if the trusted aggregator timeout expired,
         // Note that the sequencedBatches struct must exists for this finalNewBatch, if not newAccInputHash will be 0
         if (
@@ -689,7 +689,7 @@ contract PolygonZkEVM is
         bytes32 newLocalExitRoot,
         bytes32 newStateRoot,
         bytes calldata proof
-    ) external onlyTrustedAggregator {
+    ) public virtual onlyTrustedAggregator {
         _verifyAndRewardBatches(
             pendingStateNum,
             initNumBatch,


### PR DESCRIPTION
This is required in order to override the function in the forkable zkevm.