### PR TITLE
making the deposit contract configurable

### DIFF
--- a/contracts/PolygonZkEVMBridgeWrapper.sol
+++ b/contracts/PolygonZkEVMBridgeWrapper.sol
@@ -9,8 +9,10 @@ contract PolygonZkEVMBridgeWrapper is PolygonZkEVMBridge{
         IBasePolygonZkEVMGlobalExitRoot _globalExitRootManager,
         address _polygonZkEVMaddress,
         address _gasTokenAddress,
-        bool _isDeployedOnL2
+        bool _isDeployedOnL2,
+        uint32 _lastUpdatedDepositCount,
+        bytes32[_DEPOSIT_CONTRACT_TREE_DEPTH] memory depositBranches
     ) public virtual override initializer {
-        PolygonZkEVMBridge.initialize(_networkID, _globalExitRootManager, _polygonZkEVMaddress, _gasTokenAddress, _isDeployedOnL2);
+        PolygonZkEVMBridge.initialize(_networkID, _globalExitRootManager, _polygonZkEVMaddress, _gasTokenAddress, _isDeployedOnL2, _lastUpdatedDepositCount, depositBranches);
     }
 }

--- a/contracts/mocks/PolygonZkEVMBridgeMock.sol
+++ b/contracts/mocks/PolygonZkEVMBridgeMock.sol
@@ -19,13 +19,17 @@ contract PolygonZkEVMBridgeMock is PolygonZkEVMBridgeWrapper, OwnableUpgradeable
         IBasePolygonZkEVMGlobalExitRoot _globalExitRootManager,
         address _polygonZkEVMaddress,
         address _gasTokenAddress,
-        bool _isDeployedOnL2
+        bool _isDeployedOnL2,
+        uint32 _lastUpdatedDepositCount,
+        bytes32[_DEPOSIT_CONTRACT_TREE_DEPTH] memory depositBranches
     ) public override initializer {
         networkID = _networkID;
         globalExitRootManager = _globalExitRootManager;
         polygonZkEVMaddress = _polygonZkEVMaddress;
         gasTokenAddress = _gasTokenAddress;
         isDeployedOnL2= _isDeployedOnL2;
+        lastUpdatedDepositCount = _lastUpdatedDepositCount;
+        DepositContract.initialize(lastUpdatedDepositCount, depositBranches);
 
         maxEtherBridge = 0.25 ether;
 

--- a/test/contracts/bridge.test.js
+++ b/test/contracts/bridge.test.js
@@ -41,6 +41,7 @@ describe('PolygonZkEVMBridge Contract - for L2', () => {
     let polygonZkEVMBridgeContract;
     let tokenContract;
     let gasTokenContract;
+    const depositBranches = new Array(32).fill(ethers.constants.HashZero);
 
     beforeEach('Deploy contracts', async () => {
         // load signers
@@ -72,6 +73,8 @@ describe('PolygonZkEVMBridge Contract - for L2', () => {
             polygonZkEVMAddress,
             gasTokenContract.address,
             true,
+            0,
+            depositBranches,
         );
 
         // deploy token
@@ -1201,11 +1204,15 @@ describe('PolygonZkEVMBridge Contract - for L1', () => {
     let polygonZkEVMBridgeContract;
     let tokenContract;
     let gasTokenContract;
+    const depositBranches = new Array(32);
 
     beforeEach('Deploy contracts', async () => {
         // load signers
         [deployer, rollup, acc1] = await ethers.getSigners();
 
+        for (let i = 0; i < 32; i++) {
+            depositBranches[i] = ethers.utils.hexlify(ethers.utils.randomBytes(32));
+        }
         // deploy gas token
         const gasTokenFactory = await ethers.getContractFactory('ERC20PermitMock');
         gasTokenContract = await gasTokenFactory.deploy(
@@ -1232,6 +1239,8 @@ describe('PolygonZkEVMBridge Contract - for L1', () => {
             polygonZkEVMAddress,
             gasTokenContract.address,
             false,
+            0,
+            depositBranches,
         );
 
         // deploy token

--- a/test/contracts/bridgeMock.test.js
+++ b/test/contracts/bridgeMock.test.js
@@ -35,6 +35,7 @@ describe('PolygonZkEVMBridge Mock Contract', () => {
 
     const LEAF_TYPE_ASSET = 0;
     const polygonZkEVMAddress = ethers.constants.AddressZero;
+    const depositBranches = new Array(32).fill(ethers.constants.HashZero);
 
     beforeEach('Deploy contracts', async () => {
         // load signers
@@ -65,6 +66,8 @@ describe('PolygonZkEVMBridge Mock Contract', () => {
             polygonZkEVMAddress,
             gasTokenContract.address,
             true,
+            0,
+            depositBranches,
         );
 
         // deploy token

--- a/test/contracts/bridge_metadata.test.js
+++ b/test/contracts/bridge_metadata.test.js
@@ -24,6 +24,7 @@ describe('PolygonZkEVMBridge Contract werid metadata', () => {
     const networkIDMainnet = 0;
     const networkIDRollup = 1;
     const LEAF_TYPE_ASSET = 0;
+    const depositBranches = new Array(32).fill(ethers.constants.HashZero);
 
     const polygonZkEVMAddress = ethers.constants.AddressZero;
 
@@ -56,6 +57,8 @@ describe('PolygonZkEVMBridge Contract werid metadata', () => {
             polygonZkEVMAddress,
             gasTokenContract.address,
             true,
+            0,
+            depositBranches,
         );
 
         // deploy token

--- a/test/contracts/bridge_permit.test.js
+++ b/test/contracts/bridge_permit.test.js
@@ -42,6 +42,7 @@ describe('PolygonZkEVMBridge Contract Permit tests', () => {
     const networkIDMainnet = 0;
     const networkIDRollup = 1;
     const LEAF_TYPE_ASSET = 0;
+    const depositBranches = new Array(32).fill(ethers.constants.HashZero);
 
     const polygonZkEVMAddress = ethers.constants.AddressZero;
 
@@ -74,6 +75,8 @@ describe('PolygonZkEVMBridge Contract Permit tests', () => {
             polygonZkEVMAddress,
             gasTokenContract.address,
             true,
+            0,
+            depositBranches,
         );
 
         // deploy token

--- a/test/contracts/emergencyManager.test.js
+++ b/test/contracts/emergencyManager.test.js
@@ -32,6 +32,7 @@ describe('Emergency mode test', () => {
     const pendingStateTimeoutDefault = 10;
     const trustedAggregatorTimeoutDefault = 10;
     let firstDeployment = true;
+    const depositBranches = new Array(32).fill(ethers.constants.HashZero);
 
     beforeEach('Deploy contract', async () => {
         upgrades.silenceWarnings();
@@ -109,6 +110,8 @@ describe('Emergency mode test', () => {
             polygonZkEVMContract.address,
             gasTokenContract.address,
             true,
+            0,
+            depositBranches,
         );
         await polygonZkEVMContract.initialize(
             {

--- a/test/contracts/polygonZkEVM.test.js
+++ b/test/contracts/polygonZkEVM.test.js
@@ -39,6 +39,7 @@ describe('Polygon ZK-EVM', () => {
     const pendingStateTimeoutDefault = 100;
     const trustedAggregatorTimeoutDefault = 10;
     let firstDeployment = true;
+    const depositBranches = new Array(32).fill(ethers.constants.HashZero);
 
     // PolygonZkEVM Constants
     const FORCE_BATCH_TIMEOUT = 60 * 60 * 24 * 5; // 5 days
@@ -119,6 +120,8 @@ describe('Polygon ZK-EVM', () => {
             polygonZkEVMContract.address,
             gasTokenContract.address,
             true,
+            0,
+            depositBranches,
         );
         await polygonZkEVMContract.initialize(
             {

--- a/test/contracts/polygonZkEVMTestnetV2.test.js
+++ b/test/contracts/polygonZkEVMTestnetV2.test.js
@@ -35,6 +35,7 @@ describe('Polygon ZK-EVM TestnetV2', () => {
     const trustedAggregatorTimeoutDefault = 10;
     let firstDeployment = true;
     let doesNeedImplementationDeployment = true;
+    const depositBranches = new Array(32).fill(ethers.constants.HashZero);
 
     beforeEach('Deploy contract', async () => {
         upgrades.silenceWarnings();
@@ -110,6 +111,8 @@ describe('Polygon ZK-EVM TestnetV2', () => {
             polygonZkEVMContract.address,
             gasTokenContract.address,
             true,
+            0,
+            depositBranches,
         );
         await polygonZkEVMContract.initialize(
             {


### PR DESCRIPTION
This PR contains two modifications.

Allowing to set the parameters of the deposit contract, instead of always assuming an empty deposit list. This is necessary for the forking process.
And it makes some functions overrideable.